### PR TITLE
Update existing labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[//]: # (Release links)
+[//]: # (Issue/PR links)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ With `labeler`, managing your GitHub labels becomes effortless. `labeler` will a
 
 ## Infered values and environment variables
 
-`labeler` will automatically detect the owner or organization and the repostiory from the directory where you are running the command. It will also look for a file named `labels.yml`.
+`labeler` will automatically detect the owner or organization and the repostiory from the directory where you are running the command. It will also look automatically for a file named `labels.yml`.
 
 The following environment variables are used by `labeler`:
 
@@ -22,6 +22,12 @@ The following environment variables are used by `labeler`:
 1. Infered information from current directory
 2. environment variables
 3. CLI arguments
+
+## Existing labels
+
+For existing labels, description and color will be updated to match the content of `the labels.yml` file.
+
+However, **labels cannot be renamed**. this is due to the fact that the tool does not keep track of the existing configuration. If the name of a label gets changed, a new label will be created instead.
 
 ## Usage examples
 

--- a/labeler/labeler.go
+++ b/labeler/labeler.go
@@ -66,10 +66,14 @@ func (l *Labeler) Apply(sync bool, labelFile string) error {
 		ctx := context.Background()
 		_, r, err := l.Client.Issues.CreateLabel(ctx, l.Owner, l.Repository, ghLabel)
 
-		// Ignore error if the label already exists.
+		// Update the label if the it already exists.
 		if r.StatusCode == 422 {
+			if _, _, err := l.Client.Issues.EditLabel(ctx, l.Owner, l.Repository, *ghLabel.Name, ghLabel); err != nil {
+				return fmt.Errorf("cannot update label: %s", err)
+			}
 			continue
 		}
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Updates existing labels instead of skipping them.

As the name of the label is used as the key, we cannot rename labels!
Only the color and the description will be updated.

The `README.md` was updated accordingly.

Drive-by:
* Adds a Changelog file in prevision for future actual releases.