### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,12 @@ jobs:
           version: "2.8.0"
       - name: Install tools
         run: |
+          KEEPARELEASE_VERSION=1.2.0
           mkdir -p bin
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.21.0
-          curl -sLO https://github.com/rgreinho/keeparelease/releases/download/1.1.2/keeparelease-1.1.2-linux-amd64
-          chmod a+x keeparelease-1.1.2-linux-amd64
-          mv keeparelease-1.1.2-linux-amd64 bin/keeparelease
+          curl -sLO https://github.com/rgreinho/keeparelease/releases/download/${KEEPARELEASE_VERSION}/keeparelease-${KEEPARELEASE_VERSION}-linux-amd64
+          chmod a+x keeparelease-${KEEPARELEASE_VERSION}-linux-amd64
+          mv keeparelease-${KEEPARELEASE_VERSION}-linux-amd64 bin/keeparelease
           echo "::add-path::$GITHUB_WORKSPACE/bin"
 
       # Setup the project.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![](https://github.com/rgreinho/labeler/workflows/ci/badge.svg)
 
-
 Manage your GitHub labels efficiently.
 
 With `labeler`, managing your GitHub labels becomes effortless. `labeler` will attempt to detect all the information required to apply the labels wherever you need them to be.
@@ -101,6 +100,8 @@ labeler apply --org
 labeler apply --sync --org
 ```
 
+> *NOTE: without the `--sync` option, existing labels are updated and new labels added. Nothing gets removed.*
+
 #### Apply labels to the current repository
 
 ```bash
@@ -113,10 +114,14 @@ labeler apply [--sync]
 labeler apply [--sync] --repository other-repository
 ```
 
-#### Apply labels from a random directory
+### Apply labels from a random directory
 
 You may want to run `labeler` from anywhere on your system. Not a problem, simply pass all the values to the CLI:
 
 ```bash
-labeler apply [--sync] --owner myself --repository my-repository --token ${OTHER_GITHUB_TOKEN} /tmp/my-label-file.yml
+labeler apply [--sync] \
+  --owner myself \
+  --repository my-repository \
+  --token ${OTHER_GITHUB_TOKEN} \
+  /tmp/my-label-file.yml
 ```


### PR DESCRIPTION
Updates the CI to use the latest version of `keep a release`.

Drive-by:
* Updates the README.